### PR TITLE
Fix: Corrected Link to Collibra Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Meta\#Grid is an open source data catalog for metadata management. It is designe
 <a name="collibra"></a>
 ### Collibra
 
-[Website](https://github.com/collibra) | [GitHub](https://github.com/collibra)
+[Website](https://www.collibra.com) | [GitHub](https://github.com/collibra)
 
 Collibra is an enterprise data catalog that helps to discover and understand data that matters and drive impactful insights from it.
 


### PR DESCRIPTION
In this quick hotfix, I have corrected the link that was intended to direct users to the Collibra website but was mistakenly pointing to a location within the GitHub repo. Although a minor issue, might be good to have it solved. 

Have a wonderful day there, cheers🙌