### PR TITLE
Add FutureSearch to Data & AI Governance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repository contains a curated list of awesome Data & AI Governance platform
 |                                              |                                              | [📕 Metaplane](#metaplane)                                      |
 |                                              |                                              | [📕 BigID](#bigid)                                              |
 |                                              |                                              | [📕 OvalEdge](#ovaledge)                                        |
+|                                              |                                              | [📕 FutureSearch](#futuresearch)                                |
 
 <br>
 
@@ -1171,6 +1172,11 @@ Ataccama is an enterprise data catalog and observability tool featuring data pro
 <a name="ovaledge"></a>
 ### OvalEdge  
 [Website](https://support.ovaledge.com/) | [GitHub](https://github.com/ovaledge) 
+
+<a name="futuresearch"></a>
+### FutureSearch
+
+[Website](https://futuresearch.ai/) | [GitHub](https://github.com/futuresearch/futuresearch-python)
 
 
 <a name="cloud"></a>


### PR DESCRIPTION
Adds FutureSearch (futuresearch.ai, github.com/futuresearch/futuresearch-python) with a table-of-contents entry and a tool section, matching the existing format. FutureSearch runs AI web research agents over data for dedupe, merge, ranking, and screening. Supersedes the earlier #35, which used the project's old name "everyrow"; that one can be closed.